### PR TITLE
Fixed TraitError 'value' trait when no value is selected

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,67 @@
+ipyselect2
+==========
+
+Usage
+=====
+
+.. code:: python
+
+    from ipyselect2 import Select2
+    import ipywidgets as widgets
+
+    s1 = Select2(options=['a', 'b'], width='200px')
+    s2 = Select2(options=['x', 'y'], width='200px', multiple='multiple', lazy=True)
+    s2.layout.height = '60px'
+    def values_change(change):
+      with output:
+        print(change)
+    s1.observe(values_change, 'value')
+    s2.observe(values_change, 'values')
+    output = widgets.Output()
+    tab = widgets.Tab()
+    tab.children = [s1, s2]
+    def tab_change(x):
+      if x['new']: s2.lazy = False
+    tab.observe(tab_change, 'selected_index')
+    tab.set_title(0, 'single select')
+    tab.set_title(1, 'multiple select')
+    display(tab, output)
+
+Installation
+============
+
+A jupyter widget using `select2 <https://select2.org/>`__
+
+With pip:
+
+.. code:: bash
+
+    pip install ipyselect2
+
+To make it work for Jupyter lab:
+
+::
+
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager
+    jupyter labextension install ipyselect2
+
+If you have notebook 5.2 or below, you also need to execute:
+
+.. code:: bash
+
+    jupyter nbextension enable --py --sys-prefix ipyselect2
+
+For a development installation (requires npm),
+
+.. code:: bash
+
+    cd /opt
+    git clone https://github.com/opentradesolutions/ipyselect2.git
+    cd ipyselect2
+    pip install -e .
+    jupyter nbextension install --py --symlink --sys-prefix ipyselect2
+    jupyter nbextension enable --py --sys-prefix ipyselect2
+    jupyter labextension link js
+
+For Jupyter lab development, you may want to start Jupyter lab with
+jupyter lab --watch so it instantly picks up changes.

--- a/ipyselect2/select2.py
+++ b/ipyselect2/select2.py
@@ -1,4 +1,4 @@
-from traitlets import Unicode, Tuple, Bool
+from traitlets import CUnicode, Unicode, Tuple, Bool
 from ipywidgets import register, DOMWidget 
 from ._version import __version__
 
@@ -13,7 +13,7 @@ class Select2(DOMWidget):
     _view_module_version = Unicode(__version__).tag(sync=True)
     _model_module_version = Unicode(__version__).tag(sync=True)
 
-    value = Unicode('').tag(sync=True)
+    value = CUnicode(None).tag(sync=True)
     values = Tuple(trait=Unicode('')).tag(sync=True)
     width = Unicode('').tag(sync=True)
     placeholder = Unicode('').tag(sync=True)

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ version_ns = {}
 with open(os.path.join(here, 'ipyselect2', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
-with open('README.md', 'r') as f:
+with open('README.rst', 'r') as f:
   readme = f.read()
 
 setup_args = {

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ version_ns = {}
 with open(os.path.join(here, 'ipyselect2', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
-with open('README.rst', 'r') as f:
+with open('README.md', 'r') as f:
   readme = f.read()
 
 setup_args = {


### PR DESCRIPTION
This should fix #4 by using the casting variant of the trait.

Initializing it with `None` instead of `''` prevents it from firing a 'ghost-event' notifying about a value change from `''` to `None`.